### PR TITLE
fix: update rapidyaml requirement for Python 3.12 compatibility and add missing import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ pyvista==0.45.0
     # via -r requirements.in
 pyyaml==6.0.2
     # via trame
-rapidyaml==0.8.0
+rapidyaml==0.9.0
     # via fourcipp
 referencing==0.36.2
     # via

--- a/src/fourc_webviewer/run_webserver.py
+++ b/src/fourc_webviewer/run_webserver.py
@@ -1,5 +1,6 @@
 """Utility to run the webserver on a defined port."""
 
+from fourc_webviewer.fourc_webserver import FourCWebServer
 from fourc_webviewer_default_files import (
     DEFAULT_INPUT_FILE,
 )


### PR DESCRIPTION
rapidyaml==0.8.0 is incompatible with Python 3.12. Caused error on pip install -e .
from fourc_webviewer.fourc_webserver import FourCWebServer was removed 2 days ago. Probably accidentally.