### PR TITLE
Fix function evaluation

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ numpy
 # include fourcipp from github
 git+https://github.com/4C-multiphysics/fourcipp.git
 lnmmeshio>=5.6.3
+numexpr
 
 # development
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.18
+aiohttp==3.12.2
     # via wslink
 aiosignal==1.3.2
     # via aiohttp
@@ -34,7 +34,7 @@ distlib==0.3.9
     # via virtualenv
 filelock==3.18.0
     # via virtualenv
-fonttools==4.57.0
+fonttools==4.58.0
     # via matplotlib
 fourcipp @ git+https://github.com/4C-multiphysics/fourcipp.git
     # via -r requirements.in
@@ -42,7 +42,7 @@ frozenlist==1.6.0
     # via
     #   aiohttp
     #   aiosignal
-identify==2.6.10
+identify==2.6.12
     # via pre-commit
 idna==3.10
     # via
@@ -68,7 +68,7 @@ loguru==0.7.3
     #   lnmmeshio
 markdown-it-py==3.0.0
     # via rich
-matplotlib==3.10.1
+matplotlib==3.10.3
     # via
     #   pyvista
     #   vtk
@@ -80,14 +80,16 @@ more-itertools==10.7.0
     # via trame-server
 msgpack==1.1.0
     # via wslink
-multidict==6.4.3
+multidict==6.4.4
     # via
     #   aiohttp
     #   yarl
-narwhals==1.38.0
+narwhals==1.41.0
     # via plotly
 nodeenv==1.9.1
     # via pre-commit
+numexpr==2.10.2
+    # via -r requirements.in
 numpy==2.2.5
     # via
     #   -r requirements.in
@@ -96,6 +98,7 @@ numpy==2.2.5
     #   lnmmeshio
     #   matplotlib
     #   meshio
+    #   numexpr
     #   pandas
     #   pyvista
 packaging==25.0
@@ -116,7 +119,7 @@ platformdirs==4.3.8
     # via
     #   pooch
     #   virtualenv
-plotly==6.0.1
+plotly==6.1.2
     # via
     #   -r requirements.in
     #   trame-plotly
@@ -144,15 +147,14 @@ python-utils==3.9.1
     # via lnmmeshio
 pytz==2025.2
     # via pandas
-pyvista==0.45.0
+pyvista==0.45.2
     # via -r requirements.in
 pyyaml==6.0.2
-    # via trame
-rapidyaml==0.9.0
     # via
     #   lnmmeshio
     #   pre-commit
     #   trame
+rapidyaml==0.9.0
     # via fourcipp
 referencing==0.36.2
     # via
@@ -180,16 +182,16 @@ six==1.17.0
     # via python-dateutil
 tqdm==4.66.5
     # via lnmmeshio
-trame==3.9.0
+trame==3.9.1
     # via -r requirements.in
-trame-client==3.8.2
+trame-client==3.9.0
     # via
     #   trame
     #   trame-components
     #   trame-plotly
     #   trame-vtk
     #   trame-vuetify
-trame-common==0.2.0
+trame-common==1.0.0
     # via
     #   trame
     #   trame-client
@@ -219,7 +221,7 @@ vtk==9.4.2
     # via
     #   -r requirements.in
     #   pyvista
-wslink==2.3.3
+wslink==2.3.4
     # via
     #   trame
     #   trame-server

--- a/src/fourc_webviewer/input_file_utils/fourc_yaml_file_visualization.py
+++ b/src/fourc_webviewer/input_file_utils/fourc_yaml_file_visualization.py
@@ -5,12 +5,12 @@ import re
 from pathlib import Path
 
 import lnmmeshio
+import numexpr as ne
 import numpy as np
 import plotly.express as px
 
 from fourc_webviewer.input_file_utils.io_utils import (
     add_fourc_yaml_file_data_to_dis,
-    safely_parse_string,
 )
 
 
@@ -161,14 +161,20 @@ def return_function_from_funct_string(funct_string):
         # replace the used power sign
         funct_string_copy = funct_string_copy.replace("^", "**")
 
+        # replace variables
+        funct_string_copy = (
+            funct_string_copy.replace("x", str(x))
+            .replace("y", str(y))
+            .replace("z", str(z))
+            .replace("t", str(t))
+        )
+
         # for heaviside: np.heaviside takes two arguments -> second argument denotes the function value at the first argument -> we set it by default to 0
         funct_string_copy = re.sub(
             r"heaviside\((.*?)\)", r"heaviside(\1,0)", funct_string_copy
         )  # usage of raw strings, (.*?) is a non greedy capturing, and \1 replaces the captured value
 
-        return safely_parse_string(
-            funct_string_copy
-        )  # this parses string in as a function
+        return ne.evaluate(funct_string_copy)  # this parses string in as a function
 
     return np.frompyfunc(funct_using_eval, 4, 1)
 

--- a/src/fourc_webviewer/input_file_utils/io_utils.py
+++ b/src/fourc_webviewer/input_file_utils/io_utils.py
@@ -398,25 +398,3 @@ def get_master_and_linked_material_indices(materials_section):
         "master_mat_indices": master_mat_indices,
         "linked_mat_indices": linked_mat_indices,
     }
-
-
-def safely_parse_string(string):
-    """Safely evaluate a string containing a Python literal expression.
-
-    This function attempts to parse the input string using ast.literal_eval,
-    which safely evaluates strings containing Python literals such as strings,
-    numbers, tuples, lists, dicts, booleans, and None.
-
-    Parameters:
-        string (str): The string to evaluate.
-
-    Returns:
-        The evaluated Python object.
-
-    Raises:
-        ValueError: If the input string is not a valid Python literal.
-    """
-    try:
-        return ast.literal_eval(string)
-    except (ValueError, SyntaxError):
-        raise ValueError("Invalid input for literal_eval")


### PR DESCRIPTION
- Fixed the evaluation of functional expressions by using `numexpr`. The previous approach of using `eval` was unsafe, while `safely_parse_string` did not work properly. The latter was also removed.
- Adapted the requirements files to include `numexpr`.

In collaboration with @c-p-schmidt 