### PR TITLE
Include explicit vtk installation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ conda activate 4c-webviewer
 
 Install all requirements with:
 ```bash
+conda install -c conda-forge vtk=9.4.2
 pip install -e .
 ```
 

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ trame-plotly
 plotly
 pandas
 pyvista
-vtk
+vtk==9.4.2
 numpy
 # include fourcipp from github
 git+https://github.com/4C-multiphysics/fourcipp.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-certifi==2025.4.26
+certifi==2025.7.14
     # via requests
 cfgv==3.4.0
     # via pre-commit
@@ -27,15 +27,15 @@ cycler==0.12.1
     # via matplotlib
 deprecation==2.1.0
     # via rapidyaml
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 filelock==3.18.0
     # via virtualenv
-fonttools==4.58.0
+fonttools==4.59.0
     # via matplotlib
 fourcipp @ git+https://github.com/4C-multiphysics/fourcipp.git
     # via -r requirements.in
-frozenlist==1.6.0
+frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
@@ -47,7 +47,7 @@ idna==3.10
     #   yarl
 iniconfig==2.1.0
     # via pytest
-jsonschema==4.23.0
+jsonschema==4.25.0
     # via fourcipp
 jsonschema-rs==0.30.0
     # via fourcipp
@@ -73,19 +73,19 @@ meshio==5.3.5
     # via lnmmeshio
 more-itertools==10.7.0
     # via trame-server
-msgpack==1.1.0
+msgpack==1.1.1
     # via wslink
-multidict==6.4.4
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl
-narwhals==1.41.0
+narwhals==1.48.1
     # via plotly
 nodeenv==1.9.1
     # via pre-commit
-numexpr==2.10.2
+numexpr==2.11.0
     # via -r requirements.in
-numpy==2.2.5
+numpy==2.3.1
     # via
     #   -r requirements.in
     #   contourpy
@@ -103,7 +103,7 @@ packaging==25.0
     #   plotly
     #   pooch
     #   pytest
-pandas==2.2.3
+pandas==2.3.1
     # via -r requirements.in
 pillow==11.3.0
     # via
@@ -113,7 +113,7 @@ platformdirs==4.3.8
     # via
     #   pooch
     #   virtualenv
-plotly==6.1.2
+plotly==6.2.0
     # via
     #   -r requirements.in
     #   trame-plotly
@@ -123,15 +123,17 @@ pooch==1.8.2
     # via pyvista
 pre-commit==4.2.0
     # via -r requirements.in
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
-pygments==2.19.1
-    # via rich
+pygments==2.19.2
+    # via
+    #   pytest
+    #   rich
 pyparsing==3.2.3
     # via matplotlib
-pytest==8.3.5
+pytest==8.4.1
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -141,7 +143,7 @@ python-utils==3.9.1
     # via lnmmeshio
 pytz==2025.2
     # via pandas
-pyvista==0.45.2
+pyvista==0.45.3
     # via -r requirements.in
 pyyaml==6.0.2
     # via
@@ -158,11 +160,11 @@ requests==2.32.4
     # via pooch
 rich==14.0.0
     # via meshio
-rpds-py==0.24.0
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.10
+ruamel-yaml==0.18.14
     # via fourcipp
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
@@ -172,9 +174,9 @@ six==1.17.0
     # via python-dateutil
 tqdm==4.66.5
     # via lnmmeshio
-trame==3.9.1
+trame==3.11.0
     # via -r requirements.in
-trame-client==3.9.0
+trame-client==3.9.1
     # via
     #   trame
     #   trame-components
@@ -185,17 +187,17 @@ trame-common==1.0.0
     # via
     #   trame
     #   trame-client
-trame-components==2.4.2
+trame-components==2.5.0
     # via -r requirements.in
 trame-plotly==3.1.0
     # via -r requirements.in
-trame-server==3.4.0
+trame-server==3.5.0
     # via trame
-trame-vtk==2.8.15
+trame-vtk==2.9.1
     # via -r requirements.in
 trame-vuetify==3.0.1
     # via -r requirements.in
-typing-extensions==4.13.2
+typing-extensions==4.14.1
     # via
     #   aiosignal
     #   python-utils
@@ -205,7 +207,7 @@ tzdata==2025.2
     # via pandas
 urllib3==2.5.0
     # via requests
-virtualenv==20.31.2
+virtualenv==20.32.0
     # via pre-commit
 vtk==9.4.2
     # via
@@ -215,5 +217,5 @@ wslink==2.3.4
     # via
     #   trame
     #   trame-server
-yarl==1.20.0
+yarl==1.20.1
     # via aiohttp


### PR DESCRIPTION
Using our current installation method on three different Ubuntu 24.04 machines, I received the following error:
`vtkXOpenGLRenderWindow (0x1b337c90): Could not find a decent config`, which eventually led to a segmentation fault in the visualization upon starting the webviewer. 
Explicitly installing `vtk=9.4.2` from `conda-forge` added further required libraries and resolved the issue above. The new approach should improve robustness on the different machines running the webviewer.