### PR TITLE
build: install fourcipp from pypi

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,8 +8,7 @@ pandas
 pyvista
 vtk==9.4.2
 numpy
-# include fourcipp from github
-git+https://github.com/4C-multiphysics/fourcipp.git
+fourcipp
 lnmmeshio>=5.6.3
 numexpr
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ filelock==3.18.0
     # via virtualenv
 fonttools==4.59.0
     # via matplotlib
-fourcipp @ git+https://github.com/4C-multiphysics/fourcipp.git
+fourcipp==0.29.0
     # via -r requirements.in
 frozenlist==1.7.0
     # via

--- a/src/fourc_webviewer/fourc_webserver.py
+++ b/src/fourc_webviewer/fourc_webserver.py
@@ -296,7 +296,7 @@ class FourCWebServer:
         approach to add them up to the main section SOLVERS.
         """
 
-        self.state.json_schema = CONFIG["json_schema"]
+        self.state.json_schema = CONFIG.fourc_json_schema
 
         # define substrings of section names to exclude
         substr_to_exclude = ["DESIGN", "TOPOLOGY", "ELEMENTS", "NODE", "FUNCT"]


### PR DESCRIPTION
fourcipp is now available from pypi, so no need to download it via git.