### PR TITLE
Add 4C schema specification mechanism

### DIFF
--- a/src/fourc_webviewer/cli_utils.py
+++ b/src/fourc_webviewer/cli_utils.py
@@ -28,6 +28,11 @@ def get_arguments():
         "--fourc_yaml_file", type=str, help="input file path to visualize"
     )
     parser.add_argument(
+        "--fourc_schema_file",
+        type=str,
+        help="path to schema file to be used for validation (optional: if not specified, the schema from fourcipp is used)",
+    )
+    parser.add_argument(
         "--server",
         action="store_true",
         help="start app in server mode without opening the browser (useful for local port forwarding via ssh)",

--- a/src/fourc_webviewer/fourc_webserver.py
+++ b/src/fourc_webviewer/fourc_webserver.py
@@ -3,6 +3,7 @@ state, synchronizes server variables, and handles PyVista rendering for the 4C
 web viewer."""
 
 import copy
+import json
 import re
 import shutil
 import tempfile
@@ -55,17 +56,32 @@ class FourCWebServer:
     def __init__(
         self,
         fourc_yaml_file,
+        fourc_schema_file=None,
         page_title="4C Webviewer",
     ):
         """Constructor.
 
         Args:
             fourc_yaml_file (string|Path): path to the input fourc yaml file.
+            fourc_schema_file (string|Path): path to the fourc schema json file. If not provided, the default FourCIPP schema from CONFIG.fourc_json_schema is used.
             page_title (string): page title appearing in the browser
             tab.
         """
 
         self.server = get_server()
+
+        # set 4C schema: if a file was provided, read it; otherwise take the schema provided by fourcipp
+        if fourc_schema_file:
+            # check whether the provided file is really a json schema file
+            if Path(fourc_schema_file).resolve().suffix != ".json":
+                raise ValueError(
+                    f"The provided schema file {Path(fourc_schema_file)} is not a valid json file!"
+                )
+            # read schema
+            with open(fourc_schema_file, "r", encoding="utf-8") as f:
+                self.state.fourc_json_schema = json.load(f)
+        else:
+            self.state.fourc_json_schema = CONFIG.fourc_json_schema
 
         # initialize include upload value: False (bottom sheet with include upload is not displayed until there is a fourcyaml file uploaded)
         self.state.include_upload_open = False
@@ -103,7 +119,10 @@ class FourCWebServer:
             self._server_vars["fourc_yaml_size"],
             self._server_vars["fourc_yaml_last_modified"],
             self._server_vars["fourc_yaml_read_in_status"],
-        ) = read_fourc_yaml_file(fourc_yaml_file)
+        ) = read_fourc_yaml_file(
+            fourc_yaml_file=fourc_yaml_file,
+            fourc_json_schema=self.state.fourc_json_schema,
+        )
 
         if self._server_vars["fourc_yaml_read_in_status"]:
             self.state.read_in_status = self.state.all_read_in_statuses["success"]
@@ -329,20 +348,26 @@ class FourCWebServer:
         # get mesh of the selected material
         self._actors["material_meshes"] = {}
         for material in self.state.materials_section.keys():
-            # get meshes of materials
+            # get mesh of specific material
             master_mat_ind = self.determine_master_mat_ind_for_material(material)
-
-            self._actors["material_meshes"][material] = self._server_vars[
-                "render_window"
-            ].add_mesh(
-                problem_mesh.threshold(
-                    value=(master_mat_ind - 0.05, master_mat_ind + 0.05),
-                    scalars="element-material",
-                ),
-                color="darkorange",
-                opacity=0.7,
-                render=False,
+            master_mat_mesh = problem_mesh.threshold(
+                value=(master_mat_ind - 0.05, master_mat_ind + 0.05),
+                scalars="element-material",
             )
+
+            # determine whether this material has no assigned nodes
+            if len(master_mat_mesh.points) == 0:
+                self._actors["material_meshes"][material] = None
+
+            else:
+                self._actors["material_meshes"][material] = self._server_vars[
+                    "render_window"
+                ].add_mesh(
+                    master_mat_mesh,
+                    color="darkorange",
+                    opacity=0.7,
+                    render=False,
+                )
 
         all_dc_entities = [
             {"entity": k, "geometry_type": sec_name}
@@ -441,16 +466,21 @@ class FourCWebServer:
             ].SetVisibility(True)
             legend_items.append(("Selected design condition", "navy"))
 
-        for mat in self._actors.get("material_meshes", {}).values():
-            mat.SetVisibility(False)
+        for mat_mesh in self._actors.get("material_meshes", {}).values():
+            if (
+                mat_mesh is not None
+            ):  # set visibility as false for existing material meshes
+                mat_mesh.SetVisibility(False)
         if (
             self.state.selected_material
             and self.state.selected_main_section_name == "MATERIALS"
         ):
-            self._actors["material_meshes"][self.state.selected_material].SetVisibility(
-                True
-            )
-            legend_items.append(("Selected material", "orange"))
+            # only visualize material if it really has an assigned mesh
+            if self._actors["material_meshes"][self.state.selected_material]:
+                self._actors["material_meshes"][
+                    self.state.selected_material
+                ].SetVisibility(True)
+                legend_items.append(("Selected material", "orange"))
 
         self._server_vars["render_window"].remove_legend()
         if legend_items:
@@ -474,8 +504,6 @@ class FourCWebServer:
         which are handled separately. For the solvers, we take the
         approach to add them up to the main section SOLVERS.
         """
-
-        self.state.json_schema = CONFIG.fourc_json_schema
 
         # define substrings of section names to exclude
         substr_to_exclude = [
@@ -1166,7 +1194,10 @@ class FourCWebServer:
             self._server_vars["fourc_yaml_size"],
             self._server_vars["fourc_yaml_last_modified"],
             self._server_vars["fourc_yaml_read_in_status"],
-        ) = read_fourc_yaml_file(temp_fourc_yaml_file)
+        ) = read_fourc_yaml_file(
+            fourc_yaml_file=temp_fourc_yaml_file,
+            fourc_json_schema=self.state.fourc_json_schema,
+        )
         self._server_vars["fourc_yaml_name"] = Path(temp_fourc_yaml_file).name
 
         if self._server_vars["fourc_yaml_read_in_status"]:
@@ -1249,7 +1280,7 @@ class FourCWebServer:
     def click_delete_section_button(self, **kwargs):
         """Deletes the currently selected section; if it was the last
         subsection, delete the main too."""
-        if self.state.selected_section_name in self.state.json_schema.get(
+        if self.state.selected_section_name in self.state.fourc_json_schema.get(
             "required", []
         ):
             return
@@ -1298,7 +1329,7 @@ class FourCWebServer:
         add_section = self.state.add_section
         main_section_name = add_section.split("/")[0] or ""
 
-        if add_section not in self.state.json_schema.get("properties", {}):
+        if add_section not in self.state.fourc_json_schema.get("properties", {}):
             return
 
         general_sections = copy.deepcopy(self.state.general_sections) or {}
@@ -1551,7 +1582,9 @@ class FourCWebServer:
 
         # dump content to the defined export file
         self._server_vars["fourc_yaml_file_write_status"] = write_fourc_yaml_file(
-            self._server_vars["fourc_yaml_content"], self.state.export_fourc_yaml_path
+            fourc_yaml_content=self._server_vars["fourc_yaml_content"],
+            new_fourc_yaml_file=self.state.export_fourc_yaml_path,
+            fourc_json_schema=self.state.fourc_json_schema,
         )
 
         # check write status
@@ -1570,7 +1603,7 @@ class FourCWebServer:
 
             dict_leaves_to_number_if_schema(fourcinput._sections)
 
-            fourcinput.validate()
+            fourcinput.validate(json_schema=self.state.fourc_json_schema)
             self.state.input_error_dict = {}
         except ValidationError as exc:
             self.state.input_error_dict = parse_validation_error_text(

--- a/src/fourc_webviewer/gui_utils.py
+++ b/src/fourc_webviewer/gui_utils.py
@@ -648,7 +648,7 @@ def _top_row(server):
             vuetify.VAutocomplete(
                 v_model=("add_section",),
                 items=(
-                    "Object.keys(json_schema['properties']).filter(key => !new Set(['MATERIALS', 'TITLE', 'CLONING MATERIAL MAP', 'RESULT DESCRIPTION']).has(key) && !(['DESIGN', 'TOPOLOGY', 'ELEMENTS', 'NODE', 'FUNCT', 'GEOMETRY'].some(n => key.includes(n))))",
+                    "Object.keys(fourc_json_schema['properties']).filter(key => !new Set(['MATERIALS', 'TITLE', 'CLONING MATERIAL MAP', 'RESULT DESCRIPTION']).has(key) && !(['DESIGN', 'TOPOLOGY', 'ELEMENTS', 'NODE', 'FUNCT', 'GEOMETRY'].some(n => key.includes(n))))",
                 ),
                 dense=True,
                 solo=True,
@@ -689,7 +689,7 @@ def _prop_value_table(server):
             ):
                 with html.Td(classes="text-center pa-0", style="position: relative;"):
                     with vuetify.VBtn(
-                        v_if="edit_mode == all_edit_modes['edit_mode'] && !json_schema['properties']?.[selected_section_name]?.['required']?.includes(item_key)",
+                        v_if="edit_mode == all_edit_modes['edit_mode'] && !fourc_json_schema['properties']?.[selected_section_name]?.['required']?.includes(item_key)",
                         tag="a",
                         v_bind="{...props, target: '_blank'}",
                         click=(server.controller.delete_row, "[item_key]"),
@@ -709,7 +709,7 @@ def _prop_value_table(server):
                             html.Span(v_text=("item_key",), v_bind="props")
                         html.P(
                             v_text=(
-                                "json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['description'] || 'no description'",
+                                "fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['description'] || 'no description'",
                             ),
                             style="max-width: 450px;",
                         )
@@ -729,10 +729,10 @@ def _prop_value_table(server):
                             "general_sections[selected_main_section_name][selected_section_name][item_key]",  # binding item_val directly does not work, since Object.entries(...) creates copies for the mutable objects
                         ),
                         v_if=(
-                            "(json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] == 'string' "
-                            "|| json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] == 'number' "
-                            "|| json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] == 'integer')"
-                            "&& !json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['enum']"
+                            "(fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] == 'string' "
+                            "|| fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] == 'number' "
+                            "|| fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] == 'integer')"
+                            "&& !fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['enum']"
                         ),
                         blur=server.controller.on_leave_edit_field,
                         update_modelValue="flushState('general_sections')",  # this is required in order to flush the state changes correctly to the server, as our passed on v-model is a nested variable
@@ -747,7 +747,7 @@ def _prop_value_table(server):
                     # if item is a boolean -> use VSwitch
                     with html.Div(
                         v_if=(
-                            "json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] === 'boolean'"
+                            "fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[item_key]?.['type'] === 'boolean'"
                         ),
                         classes="d-flex align-center justify-center",
                     ):
@@ -769,13 +769,13 @@ def _prop_value_table(server):
                                 "[selected_section_name][item_key]"
                             ),
                             v_if=(
-                                "json_schema['properties']?.[selected_section_name]"
+                                "fourc_json_schema['properties']?.[selected_section_name]"
                                 "?.['properties']?.[item_key]?.['enum']"
                             ),
                             update_modelValue="flushState('general_sections')",
                             # bind the enum array as items
                             items=(
-                                "json_schema['properties'][selected_section_name]['properties'][item_key]['enum']",
+                                "fourc_json_schema['properties'][selected_section_name]['properties'][item_key]['enum']",
                             ),
                             dense=True,
                             solo=True,
@@ -812,7 +812,7 @@ def _prop_value_table(server):
                         update_modelValue="flushState('general_sections')",
                         # bind the enum array as items
                         items=(
-                            "Object.keys(json_schema['properties']?.[selected_section_name]?.['properties'])",
+                            "Object.keys(fourc_json_schema['properties']?.[selected_section_name]?.['properties'])",
                         ),
                         dense=True,
                         solo=True,
@@ -831,10 +831,10 @@ def _prop_value_table(server):
                     vuetify.VTextField(
                         v_model=("add_value",),
                         v_if=(
-                            "(json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] == 'string' "
-                            "|| json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] == 'number' "
-                            "|| json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] == 'integer')"
-                            "&& !json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['enum']"
+                            "(fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] == 'string' "
+                            "|| fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] == 'number' "
+                            "|| fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] == 'integer')"
+                            "&& !fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['enum']"
                         ),
                         update_modelValue="flushState('add_value')",  # this is required in order to flush the state changes correctly to the server, as our passed on v-model is a nested variable
                         classes="w-80 pb-1",
@@ -849,7 +849,7 @@ def _prop_value_table(server):
                     # if item is a boolean -> use VSwitch
                     with html.Div(
                         v_if=(
-                            "json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] === 'boolean'"
+                            "fourc_json_schema['properties']?.[selected_section_name]?.['properties']?.[add_key]?.['type'] === 'boolean'"
                         ),
                         classes="d-flex align-center justify-center",
                     ):
@@ -865,13 +865,13 @@ def _prop_value_table(server):
                         vuetify.VAutocomplete(
                             v_model=("add_value"),
                             v_if=(
-                                "json_schema['properties']?.[selected_section_name]"
+                                "fourc_json_schema['properties']?.[selected_section_name]"
                                 "?.['properties']?.[add_key]?.['enum']"
                             ),
                             update_modelValue="flushState('add_value')",
                             # bind the enum array as items
                             items=(
-                                "json_schema['properties'][selected_section_name]['properties'][add_key]['enum']",
+                                "fourc_json_schema['properties'][selected_section_name]['properties'][add_key]['enum']",
                             ),
                             dense=True,
                             solo=True,
@@ -931,7 +931,7 @@ def _materials_panel():
                 classes="ga-3 mb-5 pl-5 pr-5 w-full",
                 v_if=("edit_mode ==  all_edit_modes['view_mode']",),
                 v_text=(
-                    "json_schema?.properties?.MATERIALS?.items?.oneOf?"
+                    "fourc_json_schema?.properties?.MATERIALS?.items?.oneOf?"
                     ".find(v => v.properties?.[materials_section[selected_material]?.TYPE])?.properties?"
                     ".[materials_section[selected_material]?.TYPE]?.description || 'Error on material description'",
                 ),
@@ -996,7 +996,7 @@ def _materials_panel():
                                     html.P(v_text=("param_key",), v_bind="props")
                                 html.P(
                                     v_text=(
-                                        "json_schema?.properties?.MATERIALS?.items?.oneOf?"
+                                        "fourc_json_schema?.properties?.MATERIALS?.items?.oneOf?"
                                         ".find(v => v.properties?.[materials_section[selected_material]?.TYPE])?"
                                         ".properties?.[materials_section[selected_material]?.TYPE]?.properties?"
                                         ".[param_key]?.description || 'Error on parameter description'",
@@ -1511,7 +1511,7 @@ def create_gui(server, render_window):
                     outlined=True,
                     color="red",
                     v_if=(
-                        "!json_schema['required'].includes(selected_section_name) && Object.keys(general_sections).includes(selected_main_section_name)",
+                        "!fourc_json_schema['required'].includes(selected_section_name) && Object.keys(general_sections).includes(selected_main_section_name)",
                     ),
                     click=server.controller.click_delete_section_button,
                 )

--- a/src/fourc_webviewer/input_file_utils/io_utils.py
+++ b/src/fourc_webviewer/input_file_utils/io_utils.py
@@ -11,13 +11,14 @@ from fourc_webviewer.global_variables import ALL_DC_GEOMETRIES
 from fourc_webviewer.python_utils import flatten_list
 
 
-def read_fourc_yaml_file(fourc_yaml_file):
+def read_fourc_yaml_file(fourc_yaml_file, fourc_json_schema):
     """Read in a given fourc yaml file. Validation is performed within the
     function.
 
     Args:
         fourc_yaml_file (str | Path): path to the fourc yaml file to be
         read.
+        fourc_json_schema (dict): utilized 4C schema
 
     Returns:
         tuple: A tuple containing the following elements:
@@ -37,7 +38,7 @@ def read_fourc_yaml_file(fourc_yaml_file):
         fourc_yaml_content.load_includes()
 
         # validate 4C yaml file
-        fourc_yaml_content.validate()
+        fourc_yaml_content.validate(json_schema=fourc_json_schema)
     except Exception as exc:
         logger.error(exc)  # currently, we throw the exception as terminal output
         return (FourCInput({}), [], 0, 0, False)
@@ -60,7 +61,7 @@ def read_fourc_yaml_file(fourc_yaml_file):
     )
 
 
-def write_fourc_yaml_file(fourc_yaml_content, new_fourc_yaml_file):
+def write_fourc_yaml_file(fourc_yaml_content, new_fourc_yaml_file, fourc_json_schema):
     """Writes given content to a fourc yaml file upon validation.
 
     Args:
@@ -68,6 +69,7 @@ def write_fourc_yaml_file(fourc_yaml_content, new_fourc_yaml_file):
         file.
         new_fourc_yaml_file (str | Path): path of the new file to write
         the content to.
+        fourc_json_schema (dict): utilized 4C schema
 
     Returns:
         bool: status of the file writing process. True means that the
@@ -76,7 +78,7 @@ def write_fourc_yaml_file(fourc_yaml_content, new_fourc_yaml_file):
 
     # validate content
     try:
-        fourc_yaml_content.validate()
+        fourc_yaml_content.validate(json_schema=fourc_json_schema)
     except Exception as exc:
         logger.error(exc)  # currently, we throw the exception as terminal output
         return False

--- a/src/fourc_webviewer/run_webserver.py
+++ b/src/fourc_webviewer/run_webserver.py
@@ -4,13 +4,14 @@ from fourc_webviewer.fourc_webserver import FourCWebServer
 from fourc_webviewer_default_files import DEFAULT_INPUT_FILE
 
 
-def run_webviewer(port, fourc_yaml_file=None, server=None):
+def run_webviewer(port, fourc_yaml_file=None, fourc_schema_file=None, server=None):
     """Runs the webviewer by creating a dedicated webserver object, starting it
     and cleaning up afterwards.
 
     Args:
         port (int): Port number to start the server on.
         fourc_yaml_file (str|Path, optional): Path to the input fourc yaml file. If None, the default input file is used.
+        fourc_schema_file (str|Path, optional): Path to the fourc schema json file.
         server (bool, optional): If True, runs in server mode without opening a browser. Useful for SSH port forwarding.
     """
 
@@ -18,7 +19,9 @@ def run_webviewer(port, fourc_yaml_file=None, server=None):
     if fourc_yaml_file is None:
         fourc_yaml_file = DEFAULT_INPUT_FILE
 
-    fourc_webserver = FourCWebServer(fourc_yaml_file)
+    fourc_webserver = FourCWebServer(
+        fourc_yaml_file, fourc_schema_file=fourc_schema_file
+    )
 
     # start the server after everything is set up
     if not (1 <= port <= 65535):


### PR DESCRIPTION
- Enable schema file specification; if not specified, the default schema from
`fourcipp` is taken. This feature enables visualizing files in local branches by specifying their validation schema locally.
- Add support for files with materials currently not assigned to any elements. Previously, the webviewer attempted
to create material meshes even for such materials, and it failed --- such files were therefore not
visualizable at all. Now, the specific material meshes are set to 'None' and they are not visualized, without throwing any errors.