### PR TITLE
Update requirements: pin numpy, add scipy

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,12 +7,12 @@ plotly
 pandas
 pyvista
 vtk==9.4.2
-numpy
+numpy>=1.24,<2.4
 fourcipp
 lnmmeshio>=5.6.3
 numexpr
 netCDF4
-
+scipy
 
 # development
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,11 @@ aiohttp==3.13.3
     # via wslink
 aiosignal==1.4.0
     # via aiohttp
-attrs==25.4.0
-    # via aiohttp
-certifi==2025.11.12
+attrs==26.1.0
+    # via
+    #   aiohttp
+    #   cyclopts
+certifi==2026.2.25
     # via
     #   netcdf4
     #   requests
@@ -20,27 +22,35 @@ cfgv==3.5.0
     # via pre-commit
 cftime==1.6.5
     # via netcdf4
-charset-normalizer==3.4.4
+charset-normalizer==3.4.6
     # via requests
 contourpy==1.3.3
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
+cyclopts==4.10.0
+    # via pyvista
 deprecation==2.1.0
     # via rapidyaml
 distlib==0.4.0
     # via virtualenv
-filelock==3.20.3
-    # via virtualenv
-fonttools==4.60.2
+docstring-parser==0.17.0
+    # via cyclopts
+docutils==0.22.4
+    # via rich-rst
+filelock==3.25.2
+    # via
+    #   python-discovery
+    #   virtualenv
+fonttools==4.62.1
     # via matplotlib
-fourcipp==1.39.0
+fourcipp==1.75.0
     # via -r requirements.in
 frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-identify==2.6.15
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via
@@ -48,9 +58,9 @@ idna==3.11
     #   yarl
 iniconfig==2.3.0
     # via pytest
-jsonschema-rs==0.37.1
+jsonschema-rs==0.45.0
     # via fourcipp
-kiwisolver==1.4.9
+kiwisolver==1.5.0
     # via matplotlib
 lnmmeshio==5.6.4
     # via -r requirements.in
@@ -60,7 +70,7 @@ loguru==0.7.3
     #   lnmmeshio
 markdown-it-py==4.0.0
     # via rich
-matplotlib==3.10.7
+matplotlib==3.10.8
     # via
     #   pyvista
     #   vtk
@@ -72,15 +82,15 @@ more-itertools==10.8.0
     # via trame-server
 msgpack==1.1.2
     # via wslink
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.12.0
+narwhals==2.18.0
     # via plotly
-netcdf4==1.7.3
+netcdf4==1.7.4
     # via -r requirements.in
-nodeenv==1.9.1
+nodeenv==1.10.0
     # via pre-commit
 numexpr==2.14.1
     # via -r requirements.in
@@ -97,32 +107,34 @@ numpy==2.3.5
     #   numexpr
     #   pandas
     #   pyvista
-packaging==25.0
+    #   scipy
+packaging==26.0
     # via
     #   deprecation
     #   matplotlib
     #   plotly
     #   pooch
     #   pytest
-pandas==2.3.3
+pandas==3.0.1
     # via -r requirements.in
 pillow==12.1.1
     # via
     #   matplotlib
     #   pyvista
-platformdirs==4.5.0
+platformdirs==4.9.4
     # via
     #   pooch
+    #   python-discovery
     #   virtualenv
-plotly==6.5.0
+plotly==6.6.0
     # via
     #   -r requirements.in
     #   trame-plotly
 pluggy==1.6.0
     # via pytest
-pooch==1.8.2
+pooch==1.9.0
     # via pyvista
-pre-commit==4.5.0
+pre-commit==4.5.1
     # via -r requirements.in
 propcache==0.4.1
     # via
@@ -132,33 +144,40 @@ pygments==2.19.2
     # via
     #   pytest
     #   rich
-pyparsing==3.2.5
+pyparsing==3.3.2
     # via matplotlib
-pytest==9.0.1
+pytest==9.0.2
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
+python-discovery==1.2.0
+    # via virtualenv
 python-utils==3.9.1
     # via lnmmeshio
-pytz==2025.2
-    # via pandas
-pyvista==0.46.4
+pyvista==0.47.1
     # via -r requirements.in
 pyyaml==6.0.3
     # via
     #   lnmmeshio
     #   pre-commit
     #   trame
-rapidyaml==0.10.0
+rapidyaml==0.11.0.post1
     # via fourcipp
-regex==2025.11.3
+regex==2026.2.28
     # via fourcipp
 requests==2.32.5
     # via pooch
-rich==14.2.0
-    # via meshio
+rich==14.3.3
+    # via
+    #   cyclopts
+    #   meshio
+    #   rich-rst
+rich-rst==1.3.2
+    # via cyclopts
+scipy==1.17.1
+    # via -r requirements.in
 scooby==0.11.0
     # via pyvista
 six==1.17.0
@@ -167,14 +186,14 @@ tqdm==4.66.5
     # via lnmmeshio
 trame==3.12.0
     # via -r requirements.in
-trame-client==3.11.2
+trame-client==3.11.3
     # via
     #   trame
     #   trame-components
     #   trame-plotly
     #   trame-vtk
     #   trame-vuetify
-trame-common==1.0.1
+trame-common==1.1.3
     # via
     #   trame
     #   trame-client
@@ -182,30 +201,28 @@ trame-components==2.5.0
     # via -r requirements.in
 trame-plotly==3.1.0
     # via -r requirements.in
-trame-server==3.8.1
+trame-server==3.10.0
     # via trame
-trame-vtk==2.10.0
+trame-vtk==2.11.3
     # via -r requirements.in
-trame-vuetify==3.1.0
+trame-vuetify==3.2.1
     # via -r requirements.in
 typing-extensions==4.15.0
     # via
     #   aiosignal
     #   python-utils
     #   pyvista
-tzdata==2025.2
-    # via pandas
 urllib3==2.6.3
     # via requests
-virtualenv==20.36.1
+virtualenv==21.2.0
     # via pre-commit
 vtk==9.4.2
     # via
     #   -r requirements.in
     #   pyvista
-wslink==2.5.0
+wslink==2.5.6
     # via
     #   trame
     #   trame-server
-yarl==1.22.0
+yarl==1.23.0
     # via aiohttp

--- a/tests/files/tutorial_solid_vtu.4C.yaml
+++ b/tests/files/tutorial_solid_vtu.4C.yaml
@@ -73,8 +73,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 720
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 
 DESIGN VOL DIRICH CONDITIONS:
   - E: 1


### PR DESCRIPTION
- Updated requirements upon addition of scipy, in preparation for the next PRs
enabling fiber visualizations.
- Pinning numpy required due to issues related to lnmmeshio (conversions of 1D
arrays of 1 element to scalar not enabled from 2.4.0 onwards). Lower bound 1.24 is given by the specification in lnmmeshio.
- Updated default input file to new 4C schema, necessary after updating the requirements.

@tuchpaul: FYI