### PR TITLE
Pin trame-vuetify version to 3.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 trame
-trame-vuetify
+trame-vuetify==3.1.0
 trame-vtk
 trame-components
 trame-plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ filelock==3.25.2
     #   virtualenv
 fonttools==4.62.1
     # via matplotlib
-fourcipp==1.75.0
+fourcipp==1.77.0
     # via -r requirements.in
 frozenlist==1.8.0
     # via
@@ -205,7 +205,7 @@ trame-server==3.10.0
     # via trame
 trame-vtk==2.11.3
     # via -r requirements.in
-trame-vuetify==3.2.1
+trame-vuetify==3.1.0
     # via -r requirements.in
 typing-extensions==4.15.0
     # via

--- a/tests/files/mat_transviso_viscoplast_refJC_log_substep.4C.yaml
+++ b/tests/files/mat_transviso_viscoplast_refJC_log_substep.4C.yaml
@@ -53,9 +53,9 @@ MATERIALS:
       YIELD_COND_A: 1
       YIELD_COND_B: 2
       YIELD_COND_F: 2.5
-      ANISOTROPY: "transvisotrop"
-      LOG_SUBSTEP: true
-      MAX_HALVE_NUM_SUBSTEP: 10
+      MAT_BEHAVIOR: "transv_isotropic"
+      TIME_INTEGRATION_HIST_VARS: logarithmic
+      MAX_SUBSTEPPING_HALVE_NUM: 10
   - MAT: 4
     MAT_ViscoplasticLawReformulatedJohnsonCook:
       STRAIN_RATE_PREFAC: 1


### PR DESCRIPTION
- trame-vuetify has updated to 3.2.0, thereby updating to vuetify3.11.2, see https://github.com/Kitware/trame-vuetify/compare/v3.1.0...v3.2.0.
- This leads to the GUI not rendering anymore, possibly due to some stricter rules introduced in the newer vuetify version in regards to the attributes of GUI elements.
- As a quickfix, this PR pins the trame-vuetify version to the previously working version. An issue in regards to a better long term solution was opened: #50.
- Also adapted the transversely-isotropic viscoplastic material test to the new 4C schema.